### PR TITLE
fix(ci): gate the merge queue on an aggregate check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,3 +85,18 @@ jobs:
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
         run: sbt ci-release
+
+  build-success:
+    name: Build and Test Success
+    needs: [build]
+    if: always()
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        scala: [all]
+        java: [temurin@17]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Fail if the build matrix did not succeed
+        if: needs.build.result != 'success'
+        run: exit 1

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,21 +1,21 @@
 queue_rules:
   - name: dependency-update
-    # Matching the build matrix by job name keeps these conditions working
-    # across Scala version bumps. `~=` is an "any" match over the list of
-    # checks, so a single green leg satisfies it on its own; requiring no
-    # failed and no pending legs is what makes this mean "the matrix passed".
+    # Build and Test Success is a single job depending on the whole build
+    # matrix, so Mergify has one exact check to wait for. Matching the matrix
+    # legs by regex instead leaves Mergify unable to tell a not-yet-reported
+    # check from an absent one, and it dequeues while the legs are running.
+    #
+    # The parenthetical is the job's matrix, which sbt-github-actions always
+    # emits; "all" is a constant, so bumping crossScalaVersions does not change
+    # this name. Changing githubWorkflowJavaVersions does.
     merge_conditions:
-      - check-success~=^Build and Test \(
-      - -check-failure~=^Build and Test \(
-      - -check-pending~=^Build and Test \(
+      - check-success=Build and Test Success (ubuntu-latest, all, temurin@17)
 
 pull_request_rules:
   - name: Merge using the merge queue
     conditions:
       - base=main
-      - check-success~=^Build and Test \(
-      - -check-failure~=^Build and Test \(
-      - -check-pending~=^Build and Test \(
+      - check-success=Build and Test Success (ubuntu-latest, all, temurin@17)
       - author=scala-steward
     actions:
       queue:

--- a/build.sbt
+++ b/build.sbt
@@ -90,3 +90,31 @@ ThisBuild / githubWorkflowArtifactUpload := false
 ThisBuild / githubWorkflowBuild := Seq(
   WorkflowStep.Sbt(List("testFull"), name = Some("Build project"))
 )
+
+// Mergify and branch protection match on check names, which for a matrix job
+// embed the Scala version. This job depends on the matrix as a whole, so its
+// check name is stable, and needs.build.result is only "success" when every
+// leg passed. always() makes it report a conclusion even when the matrix
+// fails, rather than being skipped.
+ThisBuild / githubWorkflowAddedJobs := Seq(
+  WorkflowJob(
+    id = "build-success",
+    name = "Build and Test Success",
+    steps = List(
+      WorkflowStep.Run(
+        List("exit 1"),
+        name = Some("Fail if the build matrix did not succeed"),
+        cond = Some("needs.build.result != 'success'")
+      )
+    ),
+    cond = Some("always()"),
+    needs = List("build"),
+    // sbt-github-actions always emits an os/scala/java matrix, and GitHub
+    // appends the matrix values to the check name. Empty dimensions produce a
+    // workflow GitHub rejects, so the scala dimension is a constant rather
+    // than a real version: this job builds nothing and never reads it, and it
+    // keeps the check name stable as crossScalaVersions changes.
+    scalas = List("all"),
+    javas = List(JavaSpec.temurin("17"))
+  )
+)


### PR DESCRIPTION
Fixes the merge queue dequeuing PRs whose CI is still running.

`merge_conditions` matched the build matrix legs by regex. A regex gives Mergify no way to tell a check that has not reported yet from one that will never exist, so an incomplete match set reads as terminal rather than pending, and it drops the PR with "the merge conditions cannot be satisfied due to failing checks" when nothing has failed.

This was observed on dvgica/managerial#366, dequeued 30 seconds into a CI run whose checks all went on to pass. This repo carries the same config and the same latent failure.

## Change

`Build and Test Success` depends on the `build` job rather than its matrix legs, so Mergify waits on one exact check name. `needs.build.result` is only `success` when every leg passed, and `always()` makes the job report a conclusion instead of being skipped when the matrix fails.

Versions now live only in `crossScalaVersions`; `.mergify.yml` needs no edit when they change.

## The parenthetical in the check name

sbt-github-actions renders `strategy.matrix` with `os`/`scala`/`java` unconditionally, and GitHub appends the matrix values to the check name. Empty dimensions are not a way out -- `scalas = Nil` renders `scala: []`, which GitHub rejects outright with a startup failure. So the scala dimension is pinned to the constant `"all"`. The job builds nothing and never reads it, and the name stays stable as `crossScalaVersions` changes. Changing `githubWorkflowJavaVersions` would change it.

## Verification

Ported from dvgica/managerial, where both directions were confirmed on real runs -- all legs green gives a `success` aggregate, and a deliberately failing leg gives a `failure` aggregate -- and where a scala-steward PR has since been merged through the queue by Mergify against this exact check.

Here, the generated job's check name was verified to match the `.mergify.yml` condition string exactly, and `githubWorkflowCheck` passes across the matrix.
